### PR TITLE
Fix extracting proper author information with nested tags

### DIFF
--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -153,7 +153,7 @@ class ContentExtractor(object):
                 if len(mm) > 0:
                     content = mm[0]
             else:
-                content = match.text or ''
+                content = match.text_content() or ''
             if len(content) > 0:
                 authors.extend(parse_byline(content))
 


### PR DESCRIPTION
tested with https://ekstrabladet.dk/plus/sportogspil/stor-oversigt-over-superliga-traenernes-loen-staale-spraenger-banken/7392243?icname=plus-front&icpos=63_1&iccreative=7392243

where author is in nested structure
```
<span itemprop="author" itemscope itemtype="http://schema.org/Person">
                        <span itemprop="name">
                                Klaus Egelund</span>
                    </span>
```

please consider that text_content() is the proper method and better than working with the text argument